### PR TITLE
Ignore rescuetime.nuspec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 artifacts/*.nupkg
 build/node_modules/
 build/tmp/
-src/dashlane.nuspec
+src/rescuetime.nuspec
 src/tools/chocolateyinstall.ps1
 src/tools/chocolateyuninstall.ps1


### PR DESCRIPTION
Wanted to submit a PR to bump the version to 2.13.1.1555, but I see that isn't needed now with the new build scripts.

Anyway, I spotted rescuetime.nuspec was about to be committed to source control, so I've addressed that in .gitignore.

If you could push an update to Chocolatey that would be appreciated.

Thanks.